### PR TITLE
readme: recommended settings for wav converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ It's a relatively common process: Download the Music from your Source (Spotify o
 ### Spotify
 Use a Tool to Download Spotify Music off of. For Playlists, you can use this: [Spotify Playlist Downloader Online](https://spotify-downloader.com/)
 
-After that, convert your Files into WAVE (.wav). You can use [this](https://offlineconverter.com/audio/mp3-to-wav/) Tool. Leaving the Audio Bitrate at 1411 kbps means CD Quality (recommended)
+After that, convert your Files into WAVE (.wav). You can use [this](https://offlineconverter.com/audio/mp3-to-wav/) Tool (max 320kbps bitrate, 44100 sample rate recommended).
 
 Finally, move your Downloaded .wav Files into the /src/ Directory where your Mod (NRPFarMod.dll) is located.
 
 ### YouTube
 Use a Tool to Download YouTube Music off of. You can use [this](https://en1.savefrom.net/1-youtube-video-downloader-3vV/) Tool. (Hey! I also made a [YouTube Downloader in Python](https://ilollek.net/pyd-rem/download.html)!)
 
-After that, convert your Files into WAVE (.wav). You can use [this](https://online-audio-converter.com/) Tool. Leaving the Audio Bitrate at 1411 kbps means CD Quality (recommended)
+After that, convert your Files into WAVE (.wav). You can use [this](https://offlineconverter.com/audio/mp3-to-wav/) Tool (max 320kbps bitrate, 44100 sample rate recommended).
 
 Finally, move your Downloaded .wav Files into the /src/ Directory where your Mod (NRPFarMod.dll) is located.
 


### PR DESCRIPTION
This makes the readme changes discussed in #1 about bitrate and sample rate settings when converting mp3 files to wav files. As stated [here](https://github.com/iLollek/NRPFarMod/issues/1#issuecomment-2347340482), the max recommended bitrate is 320kbps, and the sample rate is 44100, to minimize wav file sizes while keeping all of the quality of the mp3 files.

Additionally, I did change the other link for the converter from the YouTube section to use the offline version instead of the online one (also discussed in the issue [here](https://github.com/iLollek/NRPFarMod/issues/1#issuecomment-2345365790)).